### PR TITLE
Reverted the Google Earth XMLNS URLs to use http instead of https

### DIFF
--- a/haxby/db/custom/KMLExport.java
+++ b/haxby/db/custom/KMLExport.java
@@ -180,7 +180,7 @@ public class KMLExport {
 		try {
 			Document doc2 = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
 			Element kml = doc2.createElement("kml");
-			kml.setAttribute("xmlns", "https://earth.google.com/kml/2.1");
+			kml.setAttribute("xmlns", "http://earth.google.com/kml/2.1");
 			doc2.appendChild(kml);
 
 			Element topFolder = doc2.createElement("Document");
@@ -268,7 +268,7 @@ public class KMLExport {
 
 				Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
 				kml = doc.createElement("kml");
-				kml.setAttribute("xmlns", "https://earth.google.com/kml/2.1");
+				kml.setAttribute("xmlns", "http://earth.google.com/kml/2.1");
 				doc.appendChild(kml);
 
 				topFolder = doc.createElement("Document");

--- a/haxby/map/MapApp.java
+++ b/haxby/map/MapApp.java
@@ -187,7 +187,7 @@ public class MapApp implements ActionListener,
 	}
 
 
-	public final static String VERSION = "3.7.3"; // 04/12/2024
+	public final static String VERSION = "3.7.3.10"; // 07/09/2024
 	public final static String GEOMAPAPP_NAME = "GeoMapApp " + VERSION;
 	private static boolean DEV_MODE = false; 
 	

--- a/org/geomapapp/grid/KMZSave.java
+++ b/org/geomapapp/grid/KMZSave.java
@@ -68,7 +68,7 @@ public class KMZSave {
 		ByteArrayOutputStream bytes = new ByteArrayOutputStream();
 		PrintStream out = new PrintStream(bytes);
 		out.println( "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" );
-		out.println( "<kml xmlns=\"https://earth.google.com/kml/2.0\">" );
+		out.println( "<kml xmlns=\"http://earth.google.com/kml/2.0\">" );
 		Vector p0 = new Vector();
 		Vector p1 = new Vector();
 		p0.add( new Object[] { "GroundOverlay", p1 });


### PR DESCRIPTION
Fixed issue with [KML/KMZ files created with GMA being unusable in Google Earth](https://app.asana.com/0/1204873303567596/1207649759280995).