### PR TITLE
Streamlined downloading updates

### DIFF
--- a/haxby/map/MapApp.java
+++ b/haxby/map/MapApp.java
@@ -189,7 +189,7 @@ public class MapApp implements ActionListener,
 		SUPPORTED_MAPS.add(new Integer(NORTH_POLAR_MAP));
 	}
 
-	public final static String VERSION = "3.7.5"; //03/28/2025
+	public final static String VERSION = "3.7.5.2"; //08/07/2025
 	public final static String GEOMAPAPP_NAME = "GeoMapApp " + VERSION;
 	private static boolean DEV_MODE = false; 
 	static boolean isNewVersion = false;

--- a/org/geomapapp/io/GMADownload.java
+++ b/org/geomapapp/io/GMADownload.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.StringTokenizer;
 
@@ -176,22 +177,30 @@ public class GMADownload {
 		if(later.isSelected()) return;
 
 		// Switch from pointing to downloading file accroding to system and to point to webpage for download for that OS.
-		String name = "UnixInstall.html";
+		String name = "MapApp/";
 		//String name = "GeoMapApp.jar";
 		if ( jar.isSelected() ) {
 			//name = "GeoMapApp.jar";
-			name = "UnixInstall.html";
+			name += "GeoMapApp.jar";
 		}
 		else if ( exe.isSelected() ) {
 			//name = "GeoMapApp.exe";
-			name = "MSInstall.html";
+			name += "GeoMapApp.exe";
 		}
 		else if ( app.isSelected() ) {
 			//name = "GeoMapApp.dmg";
-			name = "MacInstall.html";
+			name += "GeoMapApp-" + newVersion + "-";
+			String whichArch = System.getProperty("os.arch");
+			if(whichArch.equals("aarch64")) {
+				name += "Silicon";
+			}
+			else {
+				name += "Intel";
+			}
+			name += ".dmg";
 		}
 
-		String urlName = PathUtil.getPath("PUBLIC_HOME_PATH") + name;
+		String urlName = PathUtil.getPath("ROOT_PATH") + name;
 		if(pane == JOptionPane.OK_OPTION) {
 		try {
 			BrowseURL.browseURL(urlName);


### PR DESCRIPTION
Instead of taking the user to the download page where they then have to click a link, it should simply download the appropriate version of GMA. Saves users a click and, for Mac users, some mental processing.