### PR TITLE
Moved the preferences window to the same place as the GMA window

### DIFF
--- a/haxby/map/MapApp.java
+++ b/haxby/map/MapApp.java
@@ -3214,6 +3214,7 @@ public class MapApp implements ActionListener,
 
 		// GMA 1.6.2: Add title "Preferences" to Preferences window
 		option = new JFrame("Preferences");
+		option.setLocation(frame.getLocation());
 		// Do nothing on close. Must select cancel
 		option.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
 


### PR DESCRIPTION
Even if the GMA window has moved, especially to another screen, the preferences window will show at the same place